### PR TITLE
Add options attribute

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -58,7 +58,7 @@ $ bower install leaflet-map-component
           </code></pre>
         </div>
       </section>
-      <leaflet-map id="getting_started" longitude="72.82150268554686" latitude="18.92926454727215" zoom="14"></leaflet-map>
+      <leaflet-map id="getting_started" longitude="72.82150268554686" latitude="18.92926454727215" zoom="14" options="{'zoomControl':false}"></leaflet-map>
 
       <section id="adding_markers_text">
         <div class="container">

--- a/leaflet-map-component.html
+++ b/leaflet-map-component.html
@@ -34,7 +34,7 @@ The `leaflet-map` element renders a [Leaflet](http://leafletjs.com/) map.
 <link rel="import" href="leaflet-polyline-component.html">
 <link rel="import" href="leaflet-polygon-component.html">
 
-<polymer-element name="leaflet-map" attributes="tileServer latitude longitude zoom fitToMarkers">
+<polymer-element name="leaflet-map" attributes="tileServer latitude longitude zoom fitToMarkers options">
   <template>
     <style>
      :host {
@@ -102,6 +102,15 @@ The `leaflet-map` element renders a [Leaflet](http://leafletjs.com/) map.
       * @default false
       */
      fitToMarkers: false,
+     
+     /**
+      * Pass extra configurations to the Map constructor
+      *
+      * @attribute options
+      * @type object
+      * @default {}
+      */
+     options: {},
 
      observe: {
        latitude: 'updateCenter',
@@ -113,12 +122,16 @@ The `leaflet-map` element renders a [Leaflet](http://leafletjs.com/) map.
        var lat = this.latitude;
        var lon = this.longitude;
        var zoom = this.zoom;
-
-       this.map = new L.Map( this.$.map , {
+       var opts = {
          center: new L.LatLng( this.latitude, this.longitude ),
          zoom: this.zoom,
          layers: [baseLayer]
-       } );
+       };
+       
+       if (typeof this.options === 'object')
+         Polymer.extend(opts, this.options);       
+
+       this.map = new L.Map( this.$.map , opts);
 
        this.map.on( 'zoomend', function ( event ) {
          this.zoom = event.target.getZoom();


### PR DESCRIPTION
`options` attribute allows passing extra configurations to the leaflet Map constructor.
Under the hood Polymer uses `JSON.parse` + replacing single quotes so the object keys have to be quoted.
